### PR TITLE
Add iverilog and verible-verilog-syntax support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Ignore all
+*
+
+# Unignore all with extensions
+!*.*
+
+# Unignore all dirs
+!*/
+
+# Waveform files
+*.vcd
+*.vcd.gz
+*.fsdb
+*.fsdb.gz

--- a/dev/mux/Makefile
+++ b/dev/mux/Makefile
@@ -1,19 +1,39 @@
-VCS             :=  vcs
+SHELL           := /bin/bash
 
-VCS_FLAGS       :=  -full64 -line -Mupdate +vc -sverilog +v2k \
-					-override_timescale=1ns/100ps \
-					+warn=noSTASKW_RMIEAFL\
-					-debug_access+pp +notimingcheck
+VCS             := vcs
+VCS_FLAGS       := -full64 -line -Mupdate +vc -sverilog +v2k \
+                   -override_timescale=1ns/100ps \
+                   +warn=noSTASKW_RMIEAFL\
+                   -debug_access+pp +notimingcheck
 
-HIGHLIGHT = |& grep --color -iP "\^|Warning|Error|Offending|Lint|"
+IVERILOG        := iverilog
+IVERILOG_OUT    := mux
+IVERILOG_FLAGS  := -g2012 -o $(IVERILOG_OUT)
+VVP             := vvp
 
-SV_FILES        :=  mux_2to1.sv mux_2to1_proc1.sv mux_2to1_proc2.sv
-TB_FILES        :=  mux_2to1_tb.sv
+HIGHLIGHT       := |& grep --color -iP "\^|Warning|Error|Offending|Lint|"
+
+SV_FILES        := mux_2to1.sv mux_2to1_proc1.sv mux_2to1_proc2.sv
+TB_FILES        := mux_2to1_tb.sv
 
 dont_rm         := Makefile *.sv
 
+# VCS simulation
+.PHONY: sim
 sim:
 	$(VCS) $(VCS_FLAGS) $(TB_FILES) $(SV_FILES) -R ${HIGHLIGHT}
 
+
+# Icarus Verilog simulation
+$(IVERILOG_OUT): Makefile $(SV_FILES) $(TB_FILES)
+	$(IVERILOG) $(IVERILOG_FLAGS) $(TB_FILES) $(SV_FILES)
+
+.PHONY: isim
+isim: $(IVERILOG_OUT)
+	$(VVP) $(IVERILOG_OUT) ${HIGHLIGHT}
+
+
+# Clean
+.PHONY: clean
 clean:
 	rm -rf `ls $(foreach i,$(dont_rm),$(addprefix -I,$i))`

--- a/dev/mux/mux_2to1.sv
+++ b/dev/mux/mux_2to1.sv
@@ -1,9 +1,8 @@
-module mux_2to1 #(
-) (
-    input  logic       sel_i,
-    input  logic [7:0] a_i,
-    input  logic [7:0] b_i,
-    output logic [7:0] y_o
+module mux_2to1 (
+  input  logic       sel_i,
+  input  logic [7:0] a_i,
+  input  logic [7:0] b_i,
+  output logic [7:0] y_o
 );
 
   // Continuous assignment

--- a/dev/mux/mux_2to1_proc1.sv
+++ b/dev/mux/mux_2to1_proc1.sv
@@ -1,9 +1,8 @@
-module mux_2to1_proc1 #(
-) (
-    input  logic       sel_i,
-    input  logic [7:0] a_i,
-    input  logic [7:0] b_i,
-    output logic [7:0] y_o
+module mux_2to1_proc1 (
+  input  logic       sel_i,
+  input  logic [7:0] a_i,
+  input  logic [7:0] b_i,
+  output logic [7:0] y_o
 );
 
   // Procedural 1

--- a/dev/mux/mux_2to1_proc2.sv
+++ b/dev/mux/mux_2to1_proc2.sv
@@ -1,9 +1,8 @@
-module mux_2to1_proc2 #(
-) (
-    input  logic       sel_i,
-    input  logic [7:0] a_i,
-    input  logic [7:0] b_i,
-    output logic [7:0] y_o
+module mux_2to1_proc2 (
+  input  logic       sel_i,
+  input  logic [7:0] a_i,
+  input  logic [7:0] b_i,
+  output logic [7:0] y_o
 );
 
   // Procedural 2

--- a/dev/mux/mux_2to1_tb.sv
+++ b/dev/mux/mux_2to1_tb.sv
@@ -6,10 +6,10 @@ module mux_2to1_tb ();
   logic [7:0] y_o;
 
   mux_2to1 #() u_mux_2to1_conti (
-      .sel_i(sel_i),
-      .a_i  (a_i),
-      .b_i  (b_i),
-      .y_o  (y_o)
+    .sel_i(sel_i),
+    .a_i  (a_i),
+    .b_i  (b_i),
+    .y_o  (y_o)
   );
 
   initial begin
@@ -20,12 +20,17 @@ module mux_2to1_tb ();
       #10.0;
       $display("a = %h, b = %h, sel = %h, y = %h", a_i, b_i, sel_i, y_o);
     end
-    $finish;
+    $finish();
   end
 
   initial begin
+`ifdef VCS
     $fsdbDumpfile("mux_2to1_tb.fsdb");
     $fsdbDumpvars();
+`else
+    $dumpfile("mux_2to1_tb.vcd");
+    $dumpvars(0, mux_2to1_tb);
+`endif
   end
 
 endmodule : mux_2to1_tb


### PR DESCRIPTION
* Add `iverilog` support and `verible-verilog-syntax` support
* Modify some SV code to fix `iverilog` compile error and `verible-verilog-syntax` error
* Modify some SV code to follow [lowRISC syntax guide](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md)
  - Use 2 spaces for line wrap